### PR TITLE
Allow for table elements

### DIFF
--- a/utils/chrome.py
+++ b/utils/chrome.py
@@ -63,7 +63,7 @@ class Chrome:
         """ Check HTML for bad attempts """
         tag_whitelist = [
             "a", "abbr", "address", "b", "code",
-            "cite", "pre", "em", "i", "ins", "kbd",
+            "cite", "em", "i", "ins", "kbd",
             "q", "samp", "small", "strike", "strong",
             "sub", "var", "p", "span", "div", "h1", "br",
             "h2", "h3", "h4", "h5", "h6", "pre", "img", "style",
@@ -96,7 +96,7 @@ class Chrome:
                         continue  # This one is 100% safe
 
                     if tag_name in attr_whitelist and attr.lower() in attr_whitelist[tag_name]:
-                        elif attr.lower() in attributes_with_urls:
+                        if attr.lower() in attributes_with_urls:
                             if not re.match(r"(https?|ftp)://", value.lower()):
                                 del tag.attrs[attr]
                     else:

--- a/utils/chrome.py
+++ b/utils/chrome.py
@@ -97,11 +97,11 @@ class Chrome:
                         continue  # This one is 100% safe
 
                     if tag_name in attr_whitelist and attr.lower() in attr_whitelist[tag_name]:
-                        if attr.lower() in attributes_with_urls:
+                        if attr == "rel" and value != "stylesheet":
+                            del tag.attrs[attr]
+                        elif attr.lower() in attributes_with_urls:
                             if not re.match(r"(https?|ftp)://", value.lower()):
                                 del tag.attrs[attr]
-                    elif attr == "rel" and value == "stylesheet":
-                        continue
                     else:
                         del tag.attrs[attr]
 

--- a/utils/chrome.py
+++ b/utils/chrome.py
@@ -67,7 +67,7 @@ class Chrome:
             "q", "samp", "small", "strike", "strong",
             "sub", "var", "p", "span", "div", "h1", "br",
             "h2", "h3", "h4", "h5", "h6", "pre", "img", "style",
-            "table", "tbody", "thead", "th", "tr", "td", "link"
+            "table", "tbody", "thead", "th", "tr", "td"
         ]
 
         tag_blacklist = ["script", "iframe"]
@@ -77,8 +77,7 @@ class Chrome:
 
         attr_whitelist = {
             "a": ["href", "title"],
-            "img": ["src", "alt", "width", "height", "title"],
-            "link": ["rel", "href"],
+            "img": ["src", "alt", "width", "height", "title"]
         }
 
         soup = BeautifulSoup(untrusted_html, features="html.parser")
@@ -97,8 +96,6 @@ class Chrome:
                         continue  # This one is 100% safe
 
                     if tag_name in attr_whitelist and attr.lower() in attr_whitelist[tag_name]:
-                        if attr == "rel" and value != "stylesheet":
-                            del tag.attrs[attr]
                         elif attr.lower() in attributes_with_urls:
                             if not re.match(r"(https?|ftp)://", value.lower()):
                                 del tag.attrs[attr]

--- a/utils/chrome.py
+++ b/utils/chrome.py
@@ -63,10 +63,11 @@ class Chrome:
         """ Check HTML for bad attempts """
         tag_whitelist = [
             "a", "abbr", "address", "b", "code",
-            "cite", "code", "em", "i", "ins", "kbd",
+            "cite", "pre", "em", "i", "ins", "kbd",
             "q", "samp", "small", "strike", "strong",
             "sub", "var", "p", "span", "div", "h1", "br",
-            "h2", "h3", "h4", "h5", "h6", "pre", "img", "style"
+            "h2", "h3", "h4", "h5", "h6", "pre", "img", "style",
+            "table", "tbody", "thead", "th", "tr", "td", "link"
         ]
 
         tag_blacklist = ["script", "iframe"]
@@ -77,6 +78,7 @@ class Chrome:
         attr_whitelist = {
             "a": ["href", "title"],
             "img": ["src", "alt", "width", "height", "title"],
+            "link": ["rel", "href", "crossorigin"],
         }
 
         soup = BeautifulSoup(untrusted_html, features="html.parser")

--- a/utils/chrome.py
+++ b/utils/chrome.py
@@ -78,7 +78,7 @@ class Chrome:
         attr_whitelist = {
             "a": ["href", "title"],
             "img": ["src", "alt", "width", "height", "title"],
-            "link": ["rel", "href", "crossorigin"],
+            "link": ["rel", "href"],
         }
 
         soup = BeautifulSoup(untrusted_html, features="html.parser")
@@ -100,6 +100,8 @@ class Chrome:
                         if attr.lower() in attributes_with_urls:
                             if not re.match(r"(https?|ftp)://", value.lower()):
                                 del tag.attrs[attr]
+                    elif attr == "rel" and value == "stylesheet":
+                        continue
                     else:
                         del tag.attrs[attr]
 


### PR DESCRIPTION
~~Not too sure where there can be an exploit with `<link>`, but the `rel` attribute should be forced as "stylesheet".~~

~~https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link~~